### PR TITLE
Fix/member page editor

### DIFF
--- a/swiftkind/settings.py
+++ b/swiftkind/settings.py
@@ -168,9 +168,9 @@ DJRICHTEXTFIELD_CONFIG = {
         'toolbar': 'bold italic | link image | removeformat',
         'width': 1200,
         'height': 500,
-        'plugins': 'advlist autolink lists link image charmap print preview hr anchor pagebreak emoticons',
+        'plugins': 'advlist autolink lists link image charmap print preview hr anchor pagebreak emoticons code',
         'toolbar1': 'undo redo | insert | styleselect | bold italic',
-        'toolbar2': 'alignleft aligncenter alignright alignjustify | link image emoticons',
+        'toolbar2': 'alignleft aligncenter alignright alignjustify | link image emoticons code',
         'image_advtab': True,
     }
 }

--- a/templates/member_page.html
+++ b/templates/member_page.html
@@ -20,7 +20,6 @@
 <body>
   <div id="page-wrapper">
     <div class="content-wrapper">
-      <img id="company-logo" src="{% static 'theme/images/logo.svg' %}">
       <div class="container member-content">
         {{ member_page.content|safe }}
       </div>


### PR DESCRIPTION
- Adds `code` plugin to TinyMCE enabling `HTML` code edits on page content
- Removes the company logo from the member page template